### PR TITLE
Bump from Erlang 24.0 to 24.0.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The purpose of this example is to provide details as to how one would go about u
 
 - Elixir 1.12.0 or newer
 
-- Erlang 24.0 or newer
+- Erlang 24.0.1 or newer
 
 - Phoenix 1.5.8 or newer
 


### PR DESCRIPTION
This PR supports the following features:

- bump from Erlang 24.0 to 24.0.1.