### PR TITLE
Bump to Elixir 1.12.1 and update associated documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The purpose of this example is to provide details as to how one would go about u
 
 ## Software requirements
 
-- Elixir 1.12.0 or newer
+- Elixir 1.12.1 or newer
 
 - Erlang 24.0.1 or newer
 
@@ -14,7 +14,7 @@ The purpose of this example is to provide details as to how one would go about u
 
 - PostgreSQL 13.2 or newer
 
-Note: This tutorial was updated on macOS 11.3.1.
+Note: This tutorial was updated on macOS 11.4.
 
 ## Communication
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ZeroPhoenix.Mixfile do
     [
       app: :zero_phoenix,
       version: "0.0.1",
-      elixir: "~> 1.12.0",
+      elixir: "~> 1.12.1",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This PR supports the following features:

- bump to Elixir 1.12.1
- refresh packages
- update docs
