### PR TITLE
Bumb to Erlang 24.0.2 and update docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The purpose of this example is to provide details as to how one would go about u
 
 - Elixir 1.12.1 or newer
 
-- Erlang 24.0.1 or newer
+- Erlang 24.0.2 or newer
 
-- Phoenix 1.5.8 or newer
+- Phoenix 1.5.9 or newer
 
 - PostgreSQL 13.2 or newer
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ZeroPhoenix.Mixfile do
   def project do
     [
       app: :zero_phoenix,
-      version: "0.0.1",
+      version: "2.3.1",
       elixir: "~> 1.12.1",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
This PR supports the following features:

- Bump from Erlang 24.0.1 to Erlang 24.0.2
- Update Erlang version
- Correct Phoenix version
