### PR TITLE
Add ability to pass multiple id's in the query with field 'persons'

### DIFF
--- a/lib/zero_phoenix/account/account.ex
+++ b/lib/zero_phoenix/account/account.ex
@@ -36,6 +36,31 @@ defmodule ZeroPhoenix.Account do
 
   """
   def get_person!(id), do: Repo.get!(Person, id)
+  def get_person(id), do: Repo.get(Person, id)
+
+  @doc """
+  Gets a list of persons.
+
+  ## Examples
+
+      iex> get_persons!([123])
+      {:ok, [%Person{}]}
+
+      iex> get_persons!([123, 456])
+      {:ok, [%Person{}]}
+
+  """
+  def get_persons(ids) do
+    ids
+    |> Enum.reduce([], fn id, acc ->
+      with person = %Person{} <- get_person(id) do
+        [person | acc]
+      else
+        nil -> acc
+      end
+    end)
+    |> Enum.reverse()
+  end
 
   @doc """
   Creates a person.

--- a/lib/zero_phoenix/account/account.ex
+++ b/lib/zero_phoenix/account/account.ex
@@ -39,27 +39,25 @@ defmodule ZeroPhoenix.Account do
   def get_person(id), do: Repo.get(Person, id)
 
   @doc """
-  Gets a list of persons.
+  Gets people from given list ids.
+
+  Returns `[]` if ids are empty or if ids don't exist.
 
   ## Examples
 
-      iex> get_persons!([123])
+      iex> get_people([123])
       {:ok, [%Person{}]}
 
-      iex> get_persons!([123, 456])
-      {:ok, [%Person{}]}
+      iex> get_people([456, 789])
+      {:ok, []}
 
   """
-  def get_persons(ids) do
-    ids
-    |> Enum.reduce([], fn id, acc ->
-      with person = %Person{} <- get_person(id) do
-        [person | acc]
-      else
-        nil -> acc
-      end
-    end)
-    |> Enum.reverse()
+
+  def get_people([]), do: Repo.all(Person)
+
+  def get_people(ids) do
+    from(p in Person, where: p.id in ^ids)
+    |> Repo.all()
   end
 
   @doc """

--- a/lib/zero_phoenix_web/graphql/schema.ex
+++ b/lib/zero_phoenix_web/graphql/schema.ex
@@ -19,11 +19,11 @@ defmodule ZeroPhoenixWeb.Graphql.Schema do
       end)
     end
 
-    field :persons, type: list_of(:person) do
-      arg(:ids, list_of(:id))
+    field :people, type: list_of(:person) do
+      arg(:ids, list_of(:id), default_value: [])
 
       resolve(fn %{ids: ids}, _info ->
-        {:ok, Account.get_persons(ids)}
+        {:ok, Account.get_people(ids)}
       end)
     end
   end

--- a/lib/zero_phoenix_web/graphql/schema.ex
+++ b/lib/zero_phoenix_web/graphql/schema.ex
@@ -5,6 +5,7 @@ defmodule ZeroPhoenixWeb.Graphql.Schema do
 
   alias ZeroPhoenix.Repo
   alias ZeroPhoenix.Account.Person
+  alias ZeroPhoenix.Account
 
   query do
     field :person, type: :person do
@@ -15,6 +16,14 @@ defmodule ZeroPhoenixWeb.Graphql.Schema do
           nil -> {:error, "Person id #{id} not found"}
           person -> {:ok, person}
         end
+      end)
+    end
+
+    field :persons, type: list_of(:person) do
+      arg(:ids, list_of(:id))
+
+      resolve(fn %{ids: ids}, _info ->
+        {:ok, Account.get_persons(ids)}
       end)
     end
   end


### PR DESCRIPTION
Add query using multiple id's to get list of persons matching list of id's. This allows for field queries such as `persons(id: [1,2,3])`, ignoring those id's that do not match. 